### PR TITLE
Update repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/bergie/passport-saml.git"
+    "url": "https://github.com/digabi/passport-saml.git"
   },
   "main": "./lib/passport-saml",
   "dependencies": {


### PR DESCRIPTION
A minor change but would be very helpful if a random user wants to navigate to the correct repository from NPM. Would be great for you to publish this change due to that reason.

This PR does not include a version bump.